### PR TITLE
Replace deprecated TextInputState.currentlyFocusedField

### DIFF
--- a/src/SpringScrollView.js
+++ b/src/SpringScrollView.js
@@ -498,8 +498,8 @@ export class SpringScrollView extends React.PureComponent<SpringScrollViewPropTy
   };
 
   _onTouchBegin = () => {
-    if (TextInputState.currentlyFocusedField())
-      TextInputState.blurTextInput(TextInputState.currentlyFocusedField());
+    if (TextInputState.currentlyFocusedInput())
+      TextInputState.currentlyFocusedInput().blur();
     this.props.tapToHideKeyboard && Keyboard.dismiss();
     this.props.onTouchBegin && this.props.onTouchBegin();
   };


### PR DESCRIPTION
TextInputState.currentlyFocusedField has been deprecated in React Native 0.63 and will be removed so we should use TextInputState.currentlyFocusedInput and the blur method of the TextInput component instead.